### PR TITLE
Add EnumFactoryLookup so that EnumFactory instances can be dynamically created

### DIFF
--- a/src/main/java/org/meanbean/bean/info/JavaBeanInformation.java
+++ b/src/main/java/org/meanbean/bean/info/JavaBeanInformation.java
@@ -21,11 +21,13 @@
 package org.meanbean.bean.info;
 
 import org.meanbean.util.ValidationHelper;
+import org.meanbean.util.reflect.ReflectionAccessor;
 
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -78,7 +80,17 @@ class JavaBeanInformation implements BeanInformation {
 			if ("class".equals(propertyDescriptor.getName()))
 				continue;
 			PropertyInformation propertyInformation = new PropertyDescriptorPropertyInformation(propertyDescriptor);
+			if (propertyInformation.isReadableWritable()) {
+				makeAccessible(propertyDescriptor.getReadMethod());
+				makeAccessible(propertyDescriptor.getWriteMethod());
+			}
 			properties.put(propertyInformation.getName(), propertyInformation);
+		}
+	}
+
+	private void makeAccessible(Method method) {
+		if (!method.isAccessible()) {
+			ReflectionAccessor.getInstance().makeAccessible(method);
 		}
 	}
 

--- a/src/main/java/org/meanbean/bean/info/PropertyDescriptorPropertyInformation.java
+++ b/src/main/java/org/meanbean/bean/info/PropertyDescriptorPropertyInformation.java
@@ -45,7 +45,7 @@ class PropertyDescriptorPropertyInformation implements PropertyInformation {
 	 *            The PropertyDescriptor this object will wrap.
 	 */
 	PropertyDescriptorPropertyInformation(PropertyDescriptor propertyDescriptor) {
-		name = propertyDescriptor.getName();
+		this.name = propertyDescriptor.getName();
 		this.propertyDescriptor = propertyDescriptor;
 	}
 

--- a/src/main/java/org/meanbean/factories/BasicNewObjectInstanceFactory.java
+++ b/src/main/java/org/meanbean/factories/BasicNewObjectInstanceFactory.java
@@ -22,6 +22,7 @@ package org.meanbean.factories;
 
 import org.meanbean.lang.Factory;
 import org.meanbean.util.ValidationHelper;
+import org.meanbean.util.reflect.ReflectionAccessor;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -74,7 +75,7 @@ public class BasicNewObjectInstanceFactory implements Factory<Object> {
 		Object result = null;
 		try {
 			Constructor<?> declaredConstructor = clazz.getDeclaredConstructor();
-			declaredConstructor.setAccessible(true);
+			ReflectionAccessor.getInstance().makeAccessible(declaredConstructor);
 			result = declaredConstructor.newInstance();
 		} catch (InstantiationException e) {
 			wrapAndRethrowException(e);

--- a/src/main/java/org/meanbean/factories/basic/EnumFactoryLookup.java
+++ b/src/main/java/org/meanbean/factories/basic/EnumFactoryLookup.java
@@ -1,0 +1,51 @@
+/*-
+ * ​​​
+ * meanbean
+ * ⁣⁣⁣
+ * Copyright (C) 2010 - 2020 the original author or authors.
+ * ⁣⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ﻿﻿﻿﻿﻿
+ */
+
+package org.meanbean.factories.basic;
+
+import org.kohsuke.MetaInfServices;
+import org.meanbean.factories.FactoryLookup;
+import org.meanbean.factories.NoSuchFactoryException;
+import org.meanbean.lang.Factory;
+import org.meanbean.util.Order;
+import org.meanbean.util.RandomValueGenerator;
+
+import java.lang.reflect.Type;
+
+/**
+ * FactoryLookup for EnumFactory instances
+ */
+@Order(4100)
+@MetaInfServices
+public class EnumFactoryLookup implements FactoryLookup {
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> Factory<T> getFactory(Type type) throws IllegalArgumentException, NoSuchFactoryException {
+		return (Factory<T>) new EnumFactory((Class<?>) type, RandomValueGenerator.getInstance());
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public boolean hasFactory(Type type) throws IllegalArgumentException {
+		return type instanceof Class && ((Class) type).isEnum();
+	}
+
+}

--- a/src/main/java/org/meanbean/util/reflect/JavaVersion.java
+++ b/src/main/java/org/meanbean/util/reflect/JavaVersion.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2017 The Gson authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.meanbean.util.reflect;
+
+/**
+ * Utility to check the major Java version of the current JVM.
+ */
+final class JavaVersion {
+  // Oracle defines naming conventions at http://www.oracle.com/technetwork/java/javase/versioning-naming-139433.html
+  // However, many alternate implementations differ. For example, Debian used 9-debian as the version string
+
+  private static final int majorJavaVersion = determineMajorJavaVersion();
+
+  private static int determineMajorJavaVersion() {
+    String javaVersion = System.getProperty("java.version");
+    return getMajorJavaVersion(javaVersion);
+  }
+
+  // Visible for testing only
+  static int getMajorJavaVersion(String javaVersion) {
+    int version = parseDotted(javaVersion);
+    if (version == -1) {
+      version = extractBeginningInt(javaVersion);
+    }
+    if (version == -1) {
+      return 6;  // Choose minimum supported JDK version as default
+    }
+    return version;
+  }
+
+  // Parses both legacy 1.8 style and newer 9.0.4 style 
+  private static int parseDotted(String javaVersion) {
+    try {
+      String[] parts = javaVersion.split("[._]");
+      int firstVer = Integer.parseInt(parts[0]);
+      if (firstVer == 1 && parts.length > 1) {
+        return Integer.parseInt(parts[1]);
+      } else {
+        return firstVer;
+      }
+    } catch (NumberFormatException e) {
+      return -1;
+    }
+  }
+
+  private static int extractBeginningInt(String javaVersion) {
+    try {
+      StringBuilder num = new StringBuilder();
+      for (int i = 0; i < javaVersion.length(); ++i) {
+        char c = javaVersion.charAt(i);
+        if (Character.isDigit(c)) {
+          num.append(c);
+        } else {
+          break;
+        }
+      }
+      return Integer.parseInt(num.toString());
+    } catch (NumberFormatException e) {
+      return -1;
+    }
+  }
+
+  /**
+   * @return the major Java version, i.e. '8' for Java 1.8, '9' for Java 9 etc.
+   */
+  public static int getMajorJavaVersion() {
+    return majorJavaVersion;
+  }
+
+  /**
+   * @return {@code true} if the application is running on Java 9 or later; and {@code false} otherwise.
+   */
+  public static boolean isJava9OrLater() {
+    return majorJavaVersion >= 9;
+  }
+
+  private JavaVersion() { }
+}

--- a/src/main/java/org/meanbean/util/reflect/PreJava9ReflectionAccessor.java
+++ b/src/main/java/org/meanbean/util/reflect/PreJava9ReflectionAccessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017 The Gson authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.meanbean.util.reflect;
+
+import java.lang.reflect.AccessibleObject;
+
+/**
+ * A basic implementation of {@link ReflectionAccessor} which is suitable for Java 8 and below.
+ * <p>
+ * This implementation just calls {@link AccessibleObject#setAccessible(boolean) setAccessible(true)}, which worked
+ * fine before Java 9.
+ */
+final class PreJava9ReflectionAccessor extends ReflectionAccessor {
+
+  /** {@inheritDoc} */
+  @Override
+  public void makeAccessible(AccessibleObject ao) {
+    ao.setAccessible(true);
+  }
+}

--- a/src/main/java/org/meanbean/util/reflect/ReflectionAccessor.java
+++ b/src/main/java/org/meanbean/util/reflect/ReflectionAccessor.java
@@ -19,13 +19,13 @@ import java.lang.reflect.AccessibleObject;
 
 /**
  * Provides a replacement for {@link AccessibleObject#setAccessible(boolean)}, which may be used to
- * avoid reflective access issues appeared in Java 9, like {@link java.lang.reflect.InaccessibleObjectException}
+ * avoid reflective access issues appeared in Java 9, like java.lang.reflect.InaccessibleObjectException
  * thrown or warnings like
  * <pre>
  *   WARNING: An illegal reflective access operation has occurred
  *   WARNING: Illegal reflective access by ...
  * </pre>
- * <p/>
+ * <p>
  * Works both for Java 9 and earlier Java versions.
  */
 public abstract class ReflectionAccessor {
@@ -35,14 +35,14 @@ public abstract class ReflectionAccessor {
 
   /**
    * Does the same as {@code ao.setAccessible(true)}, but never throws
-   * {@link java.lang.reflect.InaccessibleObjectException}
+   * java.lang.reflect.InaccessibleObjectException
    */
   public abstract void makeAccessible(AccessibleObject ao);
 
   /**
    * Obtains a {@link ReflectionAccessor} instance suitable for the current Java version.
    * <p>
-   * You may need one a reflective operation in your code throws {@link java.lang.reflect.InaccessibleObjectException}.
+   * You may need one a reflective operation in your code throws java.lang.reflect.InaccessibleObjectException.
    * In such a case, use {@link ReflectionAccessor#makeAccessible(AccessibleObject)} on a field, method or constructor
    * (instead of basic {@link AccessibleObject#setAccessible(boolean)}).
    */

--- a/src/main/java/org/meanbean/util/reflect/ReflectionAccessor.java
+++ b/src/main/java/org/meanbean/util/reflect/ReflectionAccessor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2017 The Gson authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.meanbean.util.reflect;
+
+import java.lang.reflect.AccessibleObject;
+
+/**
+ * Provides a replacement for {@link AccessibleObject#setAccessible(boolean)}, which may be used to
+ * avoid reflective access issues appeared in Java 9, like {@link java.lang.reflect.InaccessibleObjectException}
+ * thrown or warnings like
+ * <pre>
+ *   WARNING: An illegal reflective access operation has occurred
+ *   WARNING: Illegal reflective access by ...
+ * </pre>
+ * <p/>
+ * Works both for Java 9 and earlier Java versions.
+ */
+public abstract class ReflectionAccessor {
+
+  // the singleton instance, use getInstance() to obtain
+  private static final ReflectionAccessor instance = JavaVersion.getMajorJavaVersion() < 9 ? new PreJava9ReflectionAccessor() : new UnsafeReflectionAccessor();
+
+  /**
+   * Does the same as {@code ao.setAccessible(true)}, but never throws
+   * {@link java.lang.reflect.InaccessibleObjectException}
+   */
+  public abstract void makeAccessible(AccessibleObject ao);
+
+  /**
+   * Obtains a {@link ReflectionAccessor} instance suitable for the current Java version.
+   * <p>
+   * You may need one a reflective operation in your code throws {@link java.lang.reflect.InaccessibleObjectException}.
+   * In such a case, use {@link ReflectionAccessor#makeAccessible(AccessibleObject)} on a field, method or constructor
+   * (instead of basic {@link AccessibleObject#setAccessible(boolean)}).
+   */
+  public static ReflectionAccessor getInstance() {
+    return instance;
+  }
+}

--- a/src/main/java/org/meanbean/util/reflect/UnsafeReflectionAccessor.java
+++ b/src/main/java/org/meanbean/util/reflect/UnsafeReflectionAccessor.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2017 The Gson authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.meanbean.util.reflect;
+
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * An implementation of {@link ReflectionAccessor} based on {@link Unsafe}.
+ * <p>
+ * NOTE: This implementation is designed for Java 9. Although it should work with earlier Java releases, it is better to
+ * use {@link PreJava9ReflectionAccessor} for them.
+ */
+@SuppressWarnings({"unchecked", "rawtypes"})
+final class UnsafeReflectionAccessor extends ReflectionAccessor {
+
+  private static Class unsafeClass;
+  private final Object theUnsafe = getUnsafeInstance();
+  private final Field overrideField = getOverrideField();
+
+  /** {@inheritDoc} */
+  @Override
+  public void makeAccessible(AccessibleObject ao) {
+    boolean success = makeAccessibleWithUnsafe(ao);
+    if (!success) {
+      try {
+        // unsafe couldn't be found, so try using accessible anyway
+        ao.setAccessible(true);
+      } catch (SecurityException e) {
+        throw new IllegalStateException("sun.misc.Unsafe not found. Make fields accessible, or include sun.misc.Unsafe.", e);
+      }
+    }
+  }
+
+  // Visible for testing only
+  boolean makeAccessibleWithUnsafe(AccessibleObject ao) {
+    if (theUnsafe != null && overrideField != null) {
+      try {
+        Method method = unsafeClass.getMethod("objectFieldOffset", Field.class);
+        long overrideOffset = (Long) method.invoke(theUnsafe, overrideField);  // long overrideOffset = theUnsafe.objectFieldOffset(overrideField);
+        Method putBooleanMethod = unsafeClass.getMethod("putBoolean",  Object.class, long.class, boolean.class);
+        putBooleanMethod.invoke(theUnsafe, ao, overrideOffset, true); // theUnsafe.putBoolean(ao, overrideOffset, true);
+        return true;
+      } catch (Exception ignored) { // do nothing
+      }
+    }
+    return false;
+  }
+
+  private static Object getUnsafeInstance() {
+    try {
+      unsafeClass = Class.forName("sun.misc.Unsafe");
+      Field unsafeField = unsafeClass.getDeclaredField("theUnsafe");
+      unsafeField.setAccessible(true);
+      return unsafeField.get(null);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  private static Field getOverrideField() {
+    try {
+      return AccessibleObject.class.getDeclaredField("override");
+    } catch (NoSuchFieldException e) {
+      return null;
+    }
+  }
+}

--- a/src/test/java/org/meanbean/factories/basic/EnumFactoryTest.java
+++ b/src/test/java/org/meanbean/factories/basic/EnumFactoryTest.java
@@ -20,12 +20,16 @@
 
 package org.meanbean.factories.basic;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-
 import org.junit.Test;
 import org.meanbean.lang.Factory;
 import org.meanbean.util.RandomValueGenerator;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.meanbean.test.BeanVerifier.forClass;
 
 public class EnumFactoryTest extends BasicFactoryTestBase<Enum<?>> {
 
@@ -66,8 +70,34 @@ public class EnumFactoryTest extends BasicFactoryTestBase<Enum<?>> {
 		assertThat("Incorrect enum.", (Color) enumFactory.create(), is(Color.GREEN));
 		assertThat("Incorrect enum.", (Color) enumFactory.create(), is(Color.BLUE));
 	}
+	
+	@Test
+	public void verifyBean() {
+		forClass(ColorModel.class).verifyGettersAndSetters();
+	}
 
 	static enum Color {
 		RED, GREEN, BLUE
+	}
+
+	static class ColorModel {
+		private Set<Color> supportedColors;
+		private Map<Color, Integer> range;
+
+		public Map<Color, Integer> getRange() {
+			return range;
+		}
+
+		public void setRange(Map<Color, Integer> range) {
+			this.range = range;
+		}
+
+		public Set<Color> getSupportedColors() {
+			return supportedColors;
+		}
+
+		public void setSupportedColors(Set<Color> supportedColors) {
+			this.supportedColors = supportedColors;
+		}
 	}
 }


### PR DESCRIPTION
Add EnumFactoryLookup so that EnumFactory instances can be dynamically created
for enum-typed Collections or Maps.

Make constructors and property methods be accessible, possibly using unsafe,
so that non-public beans can be tested.

fixes issue #4 