### PR TITLE
disable scoping for factory cache.

### DIFF
--- a/src/main/java/org/meanbean/util/ServiceFactory.java
+++ b/src/main/java/org/meanbean/util/ServiceFactory.java
@@ -33,7 +33,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ServiceFactory<T> {
 
     private static final ThreadLocal<Map<String, Object>> factoryCache = ThreadLocal.withInitial(ConcurrentHashMap::new);
-    private static final ThreadLocal<AtomicInteger> threadScope = ThreadLocal.withInitial(AtomicInteger::new);
+    
+    @SuppressWarnings("unused")
+	private static final ThreadLocal<AtomicInteger> threadScope = ThreadLocal.withInitial(AtomicInteger::new);
 
     private final List<T> services;
 
@@ -47,7 +49,8 @@ public class ServiceFactory<T> {
 
         factoryCache().put(inprogressKey, inprogressKey);
         try {
-            return (ServiceFactory<T>) factoryCache().computeIfAbsent(definition.getServiceType().getName(),
+            return (ServiceFactory<T>) factoryCache().computeIfAbsent(
+            		definition.getServiceType().getName(),
                     key -> ServiceFactory.create(definition));
         } finally {
             factoryCache().remove(inprogressKey);
@@ -55,15 +58,20 @@ public class ServiceFactory<T> {
     }
 
     public static void inScope(Runnable runnable) {
-        threadScope.get().incrementAndGet();
+    	// disabled for now. see issue #8 and test for ArrayPropertyBeanWithConstructor
+//        threadScope.get().incrementAndGet();
         try {
             runnable.run();
         } finally {
-            int scope = threadScope.get().decrementAndGet();
-            if (scope == 0) {
-                factoryCache.remove();
-            }
+//            int scope = threadScope.get().decrementAndGet();
+//            if (scope == 0) {
+//                factoryCache.remove();
+//            }
         }
+    }
+    
+    public static void remove() {
+    	factoryCache.remove();
     }
 
     private static Map<String, Object> factoryCache() {

--- a/src/test/java/org/meanbean/test/BeanVerifierTest.java
+++ b/src/test/java/org/meanbean/test/BeanVerifierTest.java
@@ -21,11 +21,13 @@
 package org.meanbean.test;
 
 import org.junit.Test;
+import org.meanbean.test.beans.ArrayPropertyBeanWithConstructor;
 import org.meanbean.test.beans.Bean;
 import org.meanbean.test.beans.NonBean;
 import org.meanbean.test.beans.domain.Company;
 import org.meanbean.test.beans.domain.EmployeeId;
 import org.meanbean.test.beans.scan.ScanBean;
+import org.meanbean.util.RandomValueGenerator;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
@@ -111,6 +113,20 @@ public class BeanVerifierTest {
 
 		BeanVerifier.forClass(Company.class)
 				.withSettings(settings -> settings.addEqualsInsignificantProperty(Company::getId))
+				.verifyGettersAndSetters()
+				.verifyEqualsAndHashCode();
+	}
+
+	@Test
+	public void verifyCustomFactories() {
+		BeanVerifier.forClass(ArrayPropertyBeanWithConstructor.class)
+				.editSettings()
+				.registerFactory(ArrayPropertyBeanWithConstructor.class, () -> {
+					RandomValueGenerator randomValueGenerator = RandomValueGenerator.getInstance();
+					byte[] randomBytes = randomValueGenerator.nextBytes(8);
+					return new ArrayPropertyBeanWithConstructor(randomBytes);
+				})
+				.edited()
 				.verifyGettersAndSetters()
 				.verifyEqualsAndHashCode();
 	}

--- a/src/test/java/org/meanbean/test/beans/ArrayPropertyBeanWithConstructor.java
+++ b/src/test/java/org/meanbean/test/beans/ArrayPropertyBeanWithConstructor.java
@@ -1,0 +1,28 @@
+/*-
+ * ​​​
+ * meanbean
+ * ⁣⁣⁣
+ * Copyright (C) 2010 - 2020 the original author or authors.
+ * ⁣⁣⁣
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ﻿﻿﻿﻿﻿
+ */
+
+package org.meanbean.test.beans;
+
+public class ArrayPropertyBeanWithConstructor extends ArrayPropertyBean {
+
+	public ArrayPropertyBeanWithConstructor(byte[] data) {
+		this.setData(data);
+	}
+}


### PR DESCRIPTION
temporarily disable scoping for factory cache because that breaks
chained bean verification invocations where custom factories/services
are registered.

fixes #8