### PR TITLE
change factory caching to be explicitly keyed with an object.

### DIFF
--- a/src/main/java/org/meanbean/factories/BasicNewObjectInstanceFactory.java
+++ b/src/main/java/org/meanbean/factories/BasicNewObjectInstanceFactory.java
@@ -106,6 +106,9 @@ public class BasicNewObjectInstanceFactory implements Factory<Object> {
 		String message =
 		        "Failed to instantiate object of type [" + clazz.getName() + "] due to "
 		                + exception.getClass().getSimpleName() + ".";
+		if (exception instanceof NoSuchMethodException) {
+			message = message + " Do you need to add a custom Factory?";
+		}
 		throw new ObjectCreationException(message, exception);
 	}
 }

--- a/src/main/java/org/meanbean/factories/util/BasicFactoryLookupStrategy.java
+++ b/src/main/java/org/meanbean/factories/util/BasicFactoryLookupStrategy.java
@@ -247,7 +247,7 @@ public class BasicFactoryLookupStrategy implements FactoryLookupStrategy {
 			// hoping that the property type is a java bean. That dynamic factory is used to create random values of the property.
 			//
 			// To register a custom factory, call VerifierSettings::registerFactory or suppress with Warning.DYNAMICALLY_CREATED_FACTORY
-			logger.info("Cannot find a custom Factory. Using dynamically created factory for [{}] of type [{}]",
+			logger.info("Using dynamically created factory for [{}] of type [{}] because a custom Factory cannot be found.",
 					propertyName, propertyType.getName());
 		}
 	}

--- a/src/main/java/org/meanbean/test/BeanTester.java
+++ b/src/main/java/org/meanbean/test/BeanTester.java
@@ -150,18 +150,20 @@ public class BeanTester {
 	 * Prefer {@link BeanVerifier} or {@link BeanTesterBuilder#newBeanTester()}
 	 */
 	public BeanTester() {
-		this(RandomValueGenerator.getInstance(),
-				FactoryCollection.getInstance(),
-				FactoryLookupStrategy.getInstance(),
-				BeanInformationFactory.getInstance(),
-				new BeanPropertyTester(),
-				new ConcurrentHashMap<>(),
-				Configuration.defaultConfiguration());
+		ServiceFactory.createContext(this);
+		this.randomValueGenerator = RandomValueGenerator.getInstance();
+		this.factoryCollection = FactoryCollection.getInstance();
+		this.factoryLookupStrategy = FactoryLookupStrategy.getInstance();
+		this.beanInformationFactory = BeanInformationFactory.getInstance();
+		this.beanPropertyTester = new BeanPropertyTester();
+		this.customConfigurations = new ConcurrentHashMap<>();
+		this.defaultConfiguration = Configuration.defaultConfiguration();
 	}
 
 	BeanTester(RandomValueGenerator randomValueGenerator, FactoryCollection factoryCollection,
 			FactoryLookupStrategy factoryLookupStrategy, BeanInformationFactory beanInformationFactory,
 			BeanPropertyTester beanPropertyTester, Map<Class<?>, Configuration> configs, Configuration defaultConfiguration) {
+		ServiceFactory.createContextIfNeeded(this);
 		this.randomValueGenerator = randomValueGenerator;
 		this.factoryCollection = factoryCollection;
 		this.factoryLookupStrategy = factoryLookupStrategy;
@@ -337,11 +339,6 @@ public class BeanTester {
 	 *             If an unexpected exception occurs during testing.
 	 */
 	public void testBean(Class<?> beanClass, Configuration customConfiguration) throws IllegalArgumentException,
-			AssertionError, BeanTestException {
-		ServiceFactory.inScope(() -> doTestBean(beanClass, customConfiguration));
-	}
-
-	private void doTestBean(Class<?> beanClass, Configuration customConfiguration) throws IllegalArgumentException,
 			AssertionError, BeanTestException {
 		ValidationHelper.ensureExists("beanClass", "test bean", beanClass);
 		// Override the standard number of iterations if need be

--- a/src/main/java/org/meanbean/test/BeanVerifier.java
+++ b/src/main/java/org/meanbean/test/BeanVerifier.java
@@ -21,7 +21,6 @@
 package org.meanbean.test;
 
 import org.meanbean.util.ClassPathUtils;
-import org.meanbean.util.ServiceFactory;
 
 import java.util.function.Consumer;
 
@@ -154,9 +153,9 @@ public interface BeanVerifier {
 	 * Performs {@link #verifyGettersAndSetters()}, {@link #verifyEqualsAndHashCode()} and {@link #verifyToString()}
 	 */
 	default void verify() {
-		ServiceFactory.inScope(() -> verifyGettersAndSetters()
+		verifyGettersAndSetters()
 				.verifyEqualsAndHashCode()
-				.verifyToString());
+				.verifyToString();
 	}
 
 }

--- a/src/main/java/org/meanbean/test/BeanVerifierImpl.java
+++ b/src/main/java/org/meanbean/test/BeanVerifierImpl.java
@@ -30,13 +30,17 @@ import org.meanbean.util.ServiceFactory;
 
 import java.util.function.Consumer;
 
+import static org.meanbean.test.BeanTesterBuilder.newBeanTesterBuilderWithInheritedContext;
+
 class BeanVerifierImpl implements BeanVerifier, VerifierSettings, VerifierSettingsEditor {
 
 	private Class<?> beanClass;
-	private BeanTesterBuilder builder = BeanTesterBuilder.newBeanTesterBuilder();
+	private final BeanTesterBuilder builder;
 
 	public BeanVerifierImpl(Class<?> beanClass) {
+		ServiceFactory.createContext(this);
 		this.beanClass = beanClass;
+		this.builder = newBeanTesterBuilderWithInheritedContext();
 	}
 
 	@Override
@@ -57,27 +61,20 @@ class BeanVerifierImpl implements BeanVerifier, VerifierSettings, VerifierSettin
 
 	@Override
 	public BeanVerifier verifyGettersAndSetters() {
-		ServiceFactory.inScope(() -> {
-			builder.build().testBean(beanClass);
-		});
+		builder.build().testBean(beanClass);
 		return this;
 	}
 
 	@Override
 	public BeanVerifier verifyEqualsAndHashCode() {
-		ServiceFactory.inScope(() -> {
-			builder.buildEqualsMethodTester().testEqualsMethod(beanClass);
-			builder.buildHashCodeMethodTester().testHashCodeMethod(beanClass);
-		});
-
+		builder.buildEqualsMethodTester().testEqualsMethod(beanClass);
+		builder.buildHashCodeMethodTester().testHashCodeMethod(beanClass);
 		return this;
 	}
 
 	@Override
 	public BeanVerifier verifyToString() {
-		ServiceFactory.inScope(() -> {
-			builder.buildToStringMethodTester().testToStringMethod(beanClass);
-		});
+		builder.buildToStringMethodTester().testToStringMethod(beanClass);
 		return this;
 	}
 

--- a/src/main/java/org/meanbean/test/ToStringMethodTester.java
+++ b/src/main/java/org/meanbean/test/ToStringMethodTester.java
@@ -27,6 +27,7 @@ import org.meanbean.util.ServiceFactory;
 import org.meanbean.util.ValidationHelper;
 
 import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * Simple tester for verifying that the bean overrides the toString method
@@ -34,23 +35,28 @@ import java.util.Objects;
 public class ToStringMethodTester {
 
 	/** Factory used to gather information about a given bean and store it in a BeanInformation object. */
-	private final BeanInformationFactory beanInformationFactory = BeanInformationFactory.getInstance();
+	private final BeanInformationFactory beanInformationFactory;
 
+	static ToStringMethodTester createWithInheritedContext() {
+		return new ToStringMethodTester(ServiceFactory::createContextIfNeeded);
+	}
+	
 	/**
 	 * Prefer {@link BeanVerifier}
 	 */
 	ToStringMethodTester() {
+		this(ServiceFactory::createContext);
+	}
 
+	private ToStringMethodTester(Consumer<ToStringMethodTester> serviceCreator) {
+		serviceCreator.accept(this);
+		beanInformationFactory = BeanInformationFactory.getInstance();
 	}
 
 	/**
 	 * Simple toString() test to verify that the bean overrides toString() method and that it does not throw exception.
 	 */
 	public void testToStringMethod(Class<?> clazz) {
-		ServiceFactory.inScope(() -> doTestToStringMethod(clazz));
-	}
-
-	private void doTestToStringMethod(Class<?> clazz) {
 		ValidationHelper.ensureExists("clazz", "test hash code method", clazz);
 		FactoryLookupStrategy factoryLookupStrategy = FactoryLookupStrategy.getInstance();
 		EquivalentPopulatedBeanFactory factory = new EquivalentPopulatedBeanFactory(beanInformationFactory.create(clazz),

--- a/src/main/java/org/meanbean/util/ServiceFactory.java
+++ b/src/main/java/org/meanbean/util/ServiceFactory.java
@@ -20,102 +20,163 @@
 
 package org.meanbean.util;
 
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Loads service through META-INF/services mechanism, additionally providing caching and ordering behavior
  */
 public class ServiceFactory<T> {
 
-    private static final ThreadLocal<Map<String, Object>> factoryCache = ThreadLocal.withInitial(ConcurrentHashMap::new);
-    
-    @SuppressWarnings("unused")
-	private static final ThreadLocal<AtomicInteger> threadScope = ThreadLocal.withInitial(AtomicInteger::new);
+	private static final ServiceContextMap serviceContextMap = new ServiceContextMap();
 
-    private final List<T> services;
+	private final List<T> services;
 
-    @SuppressWarnings("unchecked")
-    static synchronized <T> ServiceFactory<T> getInstance(ServiceDefinition<T> definition) {
-        String inprogressKey = "Load of " + definition.getServiceType().getName() + " already in progress";
+	@SuppressWarnings("unchecked")
+	static synchronized <T> ServiceFactory<T> getInstance(ServiceDefinition<T> definition) {
+		String inprogressKey = "Load of " + definition.getServiceType().getName() + " already in progress";
 
-        if (factoryCache().containsKey(inprogressKey)) {
-            throw new IllegalStateException(inprogressKey);
-        }
+		Map<String, Object> contextMap = serviceContextMap.getContextMap();
+		if (contextMap.containsKey(inprogressKey)) {
+			throw new IllegalStateException(inprogressKey);
+		}
 
-        factoryCache().put(inprogressKey, inprogressKey);
-        try {
-            return (ServiceFactory<T>) factoryCache().computeIfAbsent(
-            		definition.getServiceType().getName(),
-                    key -> ServiceFactory.create(definition));
-        } finally {
-            factoryCache().remove(inprogressKey);
-        }
-    }
+		contextMap.put(inprogressKey, inprogressKey);
+		try {
+			return (ServiceFactory<T>) contextMap.computeIfAbsent(
+					definition.getServiceType().getName(),
+					key -> ServiceFactory.create(definition));
+		} finally {
+			contextMap.remove(inprogressKey);
+		}
+	}
+	
+	public static Void createContext(Object key) {
+		serviceContextMap.createContext(key);
+		return null;
+	}
 
-    public static void inScope(Runnable runnable) {
-    	// disabled for now. see issue #8 and test for ArrayPropertyBeanWithConstructor
-//        threadScope.get().incrementAndGet();
-        try {
-            runnable.run();
-        } finally {
-//            int scope = threadScope.get().decrementAndGet();
-//            if (scope == 0) {
-//                factoryCache.remove();
-//            }
-        }
-    }
-    
-    public static void remove() {
-    	factoryCache.remove();
-    }
+	public static Void createContextIfNeeded(Object key) {
+		serviceContextMap.createContextIfNeeded(key);
+		return null;
+	}
+	
+	public static boolean hasContext() {
+		return serviceContextMap.hasContext();
+		//ServiceContextMap.currentKey.get() != null;
+	}
+	
+	public static void clear() {
+		serviceContextMap.clear();
+	}
 
-    private static Map<String, Object> factoryCache() {
-        return factoryCache.get();
-    }
+	static <T> ServiceFactory<T> create(ServiceDefinition<T> definition) {
+		List<T> services = ServiceFactory.doLoad(definition);
+		return new ServiceFactory<>(services, definition);
+	}
 
-    static <T> ServiceFactory<T> create(ServiceDefinition<T> definition) {
-        List<T> services = ServiceFactory.doLoad(definition);
-        return new ServiceFactory<>(services, definition);
-    }
+	private ServiceFactory(List<T> services, ServiceDefinition<T> definition) {
+		if (services.isEmpty()) {
+			throw new IllegalArgumentException("cannot find services for " + definition.getServiceType());
+		}
+		this.services = Collections.unmodifiableList(services);
+	}
 
-    private ServiceFactory(List<T> services, ServiceDefinition<T> definition) {
-        if (services.isEmpty()) {
-            throw new IllegalArgumentException("cannot find services for " + definition.getServiceType());
-        }
-        this.services = Collections.unmodifiableList(services);
-    }
+	public T getFirst() {
+		return getAll().get(0);
+	}
 
-    public T getFirst() {
-        return getAll().get(0);
-    }
+	public List<T> getAll() {
+		return services;
+	}
 
-    public List<T> getAll() {
-        return services;
-    }
+	private static synchronized <T> List<T> doLoad(ServiceDefinition<T> serviceDefinition) {
+		ServiceLoader<T> loader = new ServiceLoader<>(serviceDefinition.getServiceType(),
+				serviceDefinition.getConstructorTypes());
+		List<T> services = loader.createAll(serviceDefinition.getConstructorArgs());
+		Collections.sort(services, getComparator());
+		return services;
+	}
 
-    private static synchronized <T> List<T> doLoad(ServiceDefinition<T> serviceDefinition) {
-        ServiceLoader<T> loader = new ServiceLoader<>(serviceDefinition.getServiceType(),
-                serviceDefinition.getConstructorTypes());
-        List<T> services = loader.createAll(serviceDefinition.getConstructorArgs());
-        Collections.sort(services, getComparator());
-        return services;
-    }
+	public static <T> Comparator<T> getComparator() {
+		return Comparator.comparingInt(ServiceFactory::getOrder);
+	}
 
-    public static <T> Comparator<T> getComparator() {
-        return Comparator.comparingInt(ServiceFactory::getOrder);
-    }
+	private static <T> int getOrder(T obj) {
+		Order order = obj.getClass().getAnnotation(Order.class);
+		if (order == null) {
+			return Order.LOWEST_PRECEDENCE;
+		}
+		return order.value();
+	}
 
-    private static <T> int getOrder(T obj) {
-        Order order = obj.getClass().getAnnotation(Order.class);
-        if (order == null) {
-            return Order.LOWEST_PRECEDENCE;
-        }
-        return order.value();
-    }
+	private static class ServiceContextMap {
 
+		private static final ThreadLocal<WeakReference<Object>> currentKey = new ThreadLocal<>();
+		
+		private Map<Object, Map<String, Object>> contextMapByKeys = new WeakHashMap<>();
+		
+		private Set<Class<?>> keyTypes = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+		public synchronized Map<String, Object> getContextMap() {
+			WeakReference<Object> ref = currentKey.get();
+			Objects.requireNonNull(ref, "context key not set");
+
+			Object key = ref.get();
+			Objects.requireNonNull(key, "context key not available");
+			return contextMapByKeys.computeIfAbsent(key, any -> new ConcurrentHashMap<>());
+		}
+
+		public boolean hasContext() {
+			WeakReference<Object> ref = currentKey.get();
+			return ref != null && ref.get() != null;
+		}
+
+		public void clear() {
+			contextMapByKeys.clear();
+			keyTypes.clear();
+			currentKey.remove();
+		}
+
+		public void createContext(Object key) {
+			verifyIdentityEquals(key);
+			currentKey.set(new WeakReference<>(key));
+		}
+
+		public void createContextIfNeeded(Object key) {
+			if (!hasContext()) {
+				createContext(key);
+			}
+		}
+
+		private void verifyIdentityEquals(Object obj) {
+			if (keyTypes.contains(obj.getClass())) {
+				return;
+			}
+
+			if (!obj.getClass().equals(Object.class)) {
+				try {
+					Method method = obj.getClass().getMethod("equals", Object.class);
+					ValidationHelper.ensure(method.getDeclaringClass().equals(Object.class),
+							"unexpected declaration class for " + method);
+
+					method = obj.getClass().getMethod("hashCode");
+					ValidationHelper.ensure(method.getDeclaringClass().equals(Object.class),
+							"unexpected declaration class for " + method);
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+			}
+
+			keyTypes.add(obj.getClass());
+		}
+	}
 }

--- a/src/main/java/org/meanbean/util/ServiceFactory.java
+++ b/src/main/java/org/meanbean/util/ServiceFactory.java
@@ -122,9 +122,9 @@ public class ServiceFactory<T> {
 
 		private static final ThreadLocal<WeakReference<Object>> currentKey = new ThreadLocal<>();
 		
-		private Map<Object, Map<String, Object>> contextMapByKeys = new WeakHashMap<>();
+		private final Map<Object, Map<String, Object>> contextMapByKeys = new WeakHashMap<>();
 		
-		private Set<Class<?>> keyTypes = Collections.newSetFromMap(new ConcurrentHashMap<>());
+		private final Set<Class<?>> keyTypes = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
 		public synchronized Map<String, Object> getContextMap() {
 			WeakReference<Object> ref = currentKey.get();
@@ -140,7 +140,7 @@ public class ServiceFactory<T> {
 			return ref != null && ref.get() != null;
 		}
 
-		public void clear() {
+		public synchronized void clear() {
 			contextMapByKeys.clear();
 			keyTypes.clear();
 			currentKey.remove();

--- a/src/test/java/org/meanbean/factories/ArrayFactoryLookupTest.java
+++ b/src/test/java/org/meanbean/factories/ArrayFactoryLookupTest.java
@@ -20,9 +20,11 @@
 
 package org.meanbean.factories;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.meanbean.lang.Factory;
 import org.meanbean.test.BeanTester;
+import org.meanbean.util.ServiceFactory;
 
 import java.util.UUID;
 
@@ -31,7 +33,13 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class ArrayFactoryLookupTest {
 
-	private ArrayFactoryLookup arrayFactoryCollection = new ArrayFactoryLookup();
+	private ArrayFactoryLookup arrayFactoryCollection;
+
+	@Before
+	public void setUp() {
+		ServiceFactory.createContext(this);
+		arrayFactoryCollection = new ArrayFactoryLookup();
+	}
 
 	@Test
 	public void hasFactory() throws Exception {

--- a/src/test/java/org/meanbean/factories/FactoryRepositoryTest.java
+++ b/src/test/java/org/meanbean/factories/FactoryRepositoryTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.meanbean.factories.basic.StringFactory;
 import org.meanbean.lang.Factory;
 import org.meanbean.util.RandomValueGenerator;
+import org.meanbean.util.ServiceFactory;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -51,6 +52,7 @@ public class FactoryRepositoryTest {
 
 	@Before
 	public void before() {
+		ServiceFactory.createContext(this);
 		factoryRepository = new FactoryRepository();
 	}
 

--- a/src/test/java/org/meanbean/test/BeanVerifierTest.java
+++ b/src/test/java/org/meanbean/test/BeanVerifierTest.java
@@ -29,6 +29,7 @@ import org.meanbean.test.beans.domain.EmployeeId;
 import org.meanbean.test.beans.scan.ScanBean;
 import org.meanbean.util.RandomValueGenerator;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
@@ -118,7 +119,27 @@ public class BeanVerifierTest {
 	}
 
 	@Test
-	public void verifyCustomFactories() {
+	public void verifyCustomFactoriesFirst() {
+		verifyCustomFactory();
+
+		verifyNoCustomFactory();
+	}
+
+	@Test
+	public void verifyCustomFactoriesLast() {
+		verifyNoCustomFactory();
+		
+		verifyCustomFactory();
+	}
+
+	private void verifyNoCustomFactory() {
+		assertThatCode(() -> {
+			BeanVerifier.forClass(ArrayPropertyBeanWithConstructor.class)
+					.verifyGettersAndSetters();
+		}).hasMessageContaining("Failed to instantiate");
+	}
+
+	private void verifyCustomFactory() {
 		BeanVerifier.forClass(ArrayPropertyBeanWithConstructor.class)
 				.editSettings()
 				.registerFactory(ArrayPropertyBeanWithConstructor.class, () -> {
@@ -129,7 +150,7 @@ public class BeanVerifierTest {
 				.edited()
 				.verifyGettersAndSetters()
 				.verifyEqualsAndHashCode();
-	}
+	};
 
 	@Test
 	public void verifyPackage() {

--- a/src/test/java/org/meanbean/util/ServiceFactoryTest.java
+++ b/src/test/java/org/meanbean/util/ServiceFactoryTest.java
@@ -20,16 +20,27 @@
 
 package org.meanbean.util;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.meanbean.bean.info.BeanInformationFactory;
 import org.meanbean.bean.info.JavaBeanInformationFactory;
+import org.meanbean.factories.FactoryCollection;
+import org.meanbean.factories.NoSuchFactoryException;
+import org.meanbean.lang.Factory;
+import org.meanbean.test.beans.FluentPropertyBean;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 public class ServiceFactoryTest {
 
+	@Before
+	public void setUp() {
+		ServiceFactory.createContext(this);
+	}
+	
 	@Test
 	public void loadSingleImplementor() throws Exception {
 		List<BeanInformationFactory> services = getAll();
@@ -46,6 +57,48 @@ public class ServiceFactoryTest {
 
 		assertThat(services1)
 				.isSameAs(services2);
+	}
+
+	@Test
+	public void testServiceFactoryScopeSpecialFirst() {
+		Object contextKey1 = new Object();
+		ServiceFactory.createContext(contextKey1);
+		verifySpecialRegistration();
+
+		Object contextKey2 = new Object();
+		ServiceFactory.createContext(contextKey2);
+		verifyNoSpecialRegistration();
+	}
+
+	@Test
+	public void testServiceFactoryScopeSpecialLast() {
+		Object contextKey1 = new Object();
+		ServiceFactory.createContext(contextKey1);
+		verifyNoSpecialRegistration();
+
+		Object contextKey2 = new Object();
+		ServiceFactory.createContext(contextKey2);
+		verifySpecialRegistration();
+	}
+
+	private void verifySpecialRegistration() {
+		FactoryCollection collection = FactoryCollection.getInstance();
+		collection.addFactory(FluentPropertyBean.class, () -> {
+			throw new IllegalStateException("forced exception");
+		});
+
+		Factory<Object> factory = collection.getFactory(FluentPropertyBean.class);
+		assertThatCode(() -> {
+			factory.create();
+		}).hasMessageContaining("forced exception");
+	}
+
+	private void verifyNoSpecialRegistration() {
+		assertThatCode(() -> {
+			FactoryCollection collection = FactoryCollection.getInstance();
+			Factory<Object> factory = collection.getFactory(FluentPropertyBean.class);
+			factory.create();
+		}).isInstanceOf(NoSuchFactoryException.class);
 	}
 
 	private List<BeanInformationFactory> getAll() {


### PR DESCRIPTION
rather than relying flaky "scope" concept, create context or cache
whose life time is tied to the object that creates the context.

outer most user-facing api objects forcibly creates context
while inner pseudo-internal objects tries to inherit the context.

fixes #8